### PR TITLE
Develop merge

### DIFF
--- a/_data/sidebars/overview_sidebar.yml
+++ b/_data/sidebars/overview_sidebar.yml
@@ -93,6 +93,9 @@ entries:
         - title: GuidanceResponse
           url: /api_guidance_response.html
           output: web
+        - title: Observation
+          url: /api_observation.html
+          output: web
         - title: Provenance
           url: /api_provenance.html
           output: web

--- a/_data/sidebars/overview_sidebar.yml
+++ b/_data/sidebars/overview_sidebar.yml
@@ -66,7 +66,7 @@ entries:
       url: /api_security.html
       output: web
       subfolders:
-      - title: API Interactions
+      - title: Interactions
         output: web
         subfolderitems:
         - title: Select ServiceDefinition
@@ -81,7 +81,7 @@ entries:
         - title: Result
           url: /api_return_guidance_response.html
           output: web  
-      - title: FHIR resources
+      - title: Resources
         output: web
         subfolderitems:
     #    - title: ActivityDefinition

--- a/index.md
+++ b/index.md
@@ -14,8 +14,8 @@ summary: A brief introduction to the Clinical Decision Support API Implementatio
 
 This Clinical Decision Support (CDS) RESTful FHIR STU3 ‘Read Only’ experimental API implementation guide supports the initiatives set out by the UEC Digital Integration Programme.
 
-The UEC Digital Integration Programme supports the delivery of the key recommendations and drivers for change that resulted from a number of NHS strategies, policies, frameworks and reviews, including the National Information Board (NIB) Health and Care 2020 framework, 
-the Urgent and Emergency Care Review, and the Five Year Forward View. To achieve the transformation of Urgent and Emergency Care, patients must be directed to or connected with the right service to meet their needs and not be sent or conveyed to high end dispositions 
+The UEC Digital Integration Programme supports the delivery of the key recommendations and drivers for change that resulted from a number of NHS strategies, policies, frameworks and reviews, including the [National Information Board (NIB) Health and Care 2020 framework]( https://www.gov.uk/government/publications/personalised-health-and-care-2020), 
+the [Urgent and Emergency Care Review](https://www.england.nhs.uk/wp-content/uploads/2015/06/trans-uec.pdf), and the [Five Year Forward View](https://www.england.nhs.uk/five-year-forward-view/). To achieve the transformation of Urgent and Emergency Care, patients must be directed to or connected with the right service to meet their needs and not be sent or conveyed to high end dispositions 
 such as Accident and Emergency or GPs, unless absolutely necessary.  
 
 ## In Scope ##

--- a/index.md
+++ b/index.md
@@ -38,3 +38,6 @@ Use cases for the CDS API are not included in this Implementation Guide. These w
 
 The following technical area is specifically excluded:
 * Assurance and system accreditation
+
+## Note for Implementors ##
+This specification is issued as an alpha, and we welcome feedback (see [Communication Channels](support_communications.html) for ways to contact us) on the specification. In particular, note that the identity of the patient is NOT part of the specification - that is to say, the CDSS will never know who the patient is, in order to deliver a recommendation. We particularly welcome any views on this from implementors.

--- a/pages/explore/api_care_plan.md
+++ b/pages/explore/api_care_plan.md
@@ -115,7 +115,9 @@ The table below gives implementation guidance in relation to the elements within
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>Reference<br>(Encounter |<br>EpisodeOfCare)</td>
     <td>Created in context of</td>
-<td></td>
+<td>
+  This MUST be populated with the Encounter for this journey, from the <code class="highlighter-rouge">ServiceDefinition.$evaluate.encounter</code>
+</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">period</code></td>

--- a/pages/explore/api_care_plan.md
+++ b/pages/explore/api_care_plan.md
@@ -80,7 +80,7 @@ The table below gives implementation guidance in relation to the elements within
       <td><code class="highlighter-rouge">1..1</code></td>
     <td>code</td>
     <td>draft | active | suspended | completed | entered-in-error | cancelled | unknown <a href="https://www.hl7.org/fhir/stu3/valueset-care-plan-status.html">CarePlanStatus (Required)</a></td>
-<td>This element should be populated with 'active' when the advice is given by the CDSS. Once the advice has been given, it should be updated by the EMS to show a value of 'completed'.</td>
+<td>This element SHOULD be populated with 'active' when the advice is given by the CDSS. Once the advice has been given, it SHOULD be updated by the EMS to show a value of 'completed'.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">intent</code></td>

--- a/pages/explore/api_general_guidance.md
+++ b/pages/explore/api_general_guidance.md
@@ -53,9 +53,9 @@ The following HTTP verbs MUST be supported to allow RESTful API interactions wit
 
 This is the [logical Id](http://hl7.org/fhir/STU3/resource.html#id) of the resource which is assigned by the server responsible for storing it. The logical identity is unique within the space of all resources of the same type on the same server, is case sensitive and can be up to 64 characters long.
 
-Once assigned, the identity MUST never change; `logical Ids` are always opaque, and external systems need not and should not attempt to determine their internal structure.
+Once assigned, the identity MUST never change; `logical Ids` are always opaque, and external systems need not and SHOULD NOT attempt to determine their internal structure.
 
-{% include important.html content="As stated above and in the FHIR&reg; standard, `logical Ids` are opaque and other systems should not attempt to determine their structure (or rely on this structure for performing interactions). Furthermore, as they are assigned by each server responsible for storing a resource they are usually implementation specific. For example, NoSQL document stores typically preferring a GUID key (for example, 0b28be67-dfce-4bb3-a6df-0d0c7b5ab4) while a relational database stores typically preferring a integer key (for example, 2345)." %} 
+{% include important.html content="As stated above and in the FHIR&reg; standard, `logical Ids` are opaque and other systems SHOULD NOT attempt to determine their structure (or rely on this structure for performing interactions). Furthermore, as they are assigned by each server responsible for storing a resource they are usually implementation specific. For example, NoSQL document stores typically preferring a GUID key (for example, 0b28be67-dfce-4bb3-a6df-0d0c7b5ab4) while a relational database stores typically preferring a integer key (for example, 2345)." %} 
 
 For further background, refer to principles of [resource identity as described in the FHIR standard](http://www.hl7.org/implement/standards/fhir/STU3/resource.html#id)  
 
@@ -85,7 +85,7 @@ Resources will commonly be referred to as part of other resources (e.g. a `Guida
 
 The CDS API defines numerous categories of error, each of which encapsulates a specific part of the request that is sent to the CDSS. Each type of error will be discussed in its own section below with the relevant response code:
 - [Resource Not found](api_general_guidance.html#resource-not-found) - this behaviour is supported when a request references a resource that cannot be resolved.
-- [Headers](api_general_guidance.html#headers) - The HTTP Authorization header must be supplied with any request and an error will be generated in the event of this header not being present. 
+- [Headers](api_general_guidance.html#headers) - The HTTP Authorization header MUST be supplied with any request and an error will be generated in the event of this header not being present. 
 - [Parameters](api_general_guidance.html#parameters) – Certain actions allow a server to specify HTTP parameters. This class of error covers problems with the way that those parameters may have been presented.
 
 <!--
@@ -163,11 +163,11 @@ Relevant error scenario(s) in relation to request parameter(s) are also listed.
 When using the MANDATORY `subject` parameter the client is referring to a Patient FHIR resource by reference. Two pieces of information are needed: 
 - the URL of the FHIR server that hosts the Patient resource.  If the URL of the server is not `https://demographics.spineservices.nhs.uk/STU3/Patient/` then this error will be thrown.
 
-- an identifier for the Patient resource being referenced. The identifier must be known to the server. In addition where NHS Digital own the business identifier scheme for a given type of FHIR resource then the logical and business identifiers will be the same. In this case the NHS number of a Patient resource is both a logical and business identifier meaning that it can be specified without the need to supply the identifier scheme. If the NHS number is missing from the patient parameter then this error will be thrown.
+- an identifier for the Patient resource being referenced. The identifier MUST be known to the server. In addition where NHS Digital own the business identifier scheme for a given type of FHIR resource then the logical and business identifiers will be the same. In this case the NHS number of a Patient resource is both a logical and business identifier meaning that it can be specified without the need to supply the identifier scheme. If the NHS number is missing from the patient parameter then this error will be thrown.
 
 -->
 #### `_format` request parameter ####
-If used, this parameter must specify one of the [mime types](api_general_guidance.html#content-types) recognised by CDSS and EMS Servers.
+If used, this parameter MUST specify one of the [mime types](api_general_guidance.html#content-types) recognised by CDSS and EMS Servers.
 
 <!--
 #### Invalid Reference URL in Pointer Create Request ####
@@ -184,12 +184,12 @@ When using the MANDATORY `type` parameter the client is referring to a pointer b
 If the search request specifies unsupported parameter values in the request, this error will be thrown. 
 
 #### masterIdentifier parameter ####
-Where masterIdentifier is a search term both the system and value parameters must be supplied.
+Where masterIdentifier is a search term both the system and value parameters MUST be supplied.
 
 #### _summary parameter ####
-The _summary parameter must have a value of “count”. If it is anything else then an error should be returned to the client.
+The _summary parameter MUST have a value of “count”. If it is anything else then an error SHOULD be returned to the client.
 
-If the _summary parameter is provided then the only other param that it can be used with is the optional _format param. If any other parameters are provided then an error should be returned to the client.
+If the _summary parameter is provided then the only other param that it can be used with is the optional _format param. If any other parameters are provided then an error SHOULD be returned to the client.
 
 -->
 ### Payload business rules ###
@@ -222,7 +222,7 @@ If the DocumentReference in the request body contains an ODS code on the custodi
 
 #### Attachment.creation ####
 This is an optional field but if supplied:
-- must be a valid FHIR [dateTime](https://www.hl7.org/fhir/STU3/datatypes.html#dateTime) 
+- MUST be a valid FHIR [dateTime](https://www.hl7.org/fhir/STU3/datatypes.html#dateTime) 
 
 
 #### DocumentReference.Status ####
@@ -242,7 +242,7 @@ This error is raised during a provider delete interaction. There is one exceptio
 - A provider delete pointer request contains a URL that resolves to a single DocumentReference however the custodian property does not match the ODS code in the fromASID header.
 
 #### relatesTo.code ####
-If the code is not set to the following values then an error must be returned: 
+If the code is not set to the following values then an error MUST be returned: 
 - replaces
 - transforms
 - signs
@@ -287,12 +287,12 @@ The below table summarises the HTTP response codes, along with the values to exp
 
 <!--
 ### Organisation not found ###
-These two Organisations are referenced in a DocumentReference. Therefore the references must point to a resolvable FHIR Organisation resource. If the URL being used to reference a given Organisation is invalid then this error will result. The URL must conform to the following rules:
-- Must be `https://directory.spineservices.nhs.uk/STU3/Organization`
-- Must supply a logical identifier which will be the organisation's ODS code:
-  - It must be a valid ODS code. 
-  - The ODS code must be an organisation that is known to the NRLS 
-  - The ODS code associated with the custodian property must be in the Provider role.
+These two Organisations are referenced in a DocumentReference. Therefore the references MUST point to a resolvable FHIR Organisation resource. If the URL being used to reference a given Organisation is invalid then this error will result. The URL MUST conform to the following rules:
+- MUST be `https://directory.spineservices.nhs.uk/STU3/Organization`
+- MUST supply a logical identifier which will be the organisation's ODS code:
+  - It MUST be a valid ODS code. 
+  - The ODS code MUST be an organisation that is known to the NRLS 
+  - The ODS code associated with the custodian property MUST be in the Provider role.
 
 If there is an exception then it should be displayed following the rules, along with the values
 to expect in the `OperationOutcome` shown in the table below.
@@ -342,4 +342,4 @@ Where the request cannot be processed, but the fault is with the receiving syste
 It is recommended for any synchronous patterns that the client sets a time out limit on the response back from the server, appropriate to an interactive process (e.g. around 1000 milliseconds).
 
 If the server does not respond within the time out period, then it is recommended that the client retry the operation. This is to allow for intermittent network errors.
-After a limited number of retries (e.g. 3-5) the client may assume that the server is unavailable and should respond appropriately. If the EMS is acting as the client (for example, in the `$evaluate` operation), this may take the form of a user interaction. If the CDSS is acting as the client, then the response will be to the EMS.
+After a limited number of retries (e.g. 3-5) the client MAY assume that the server is unavailable and SHOULD respond appropriately. If the EMS is acting as the client (for example, in the `$evaluate` operation), this may take the form of a user interaction. If the CDSS is acting as the client, then the response will be to the EMS.

--- a/pages/explore/api_general_guidance.md
+++ b/pages/explore/api_general_guidance.md
@@ -59,6 +59,11 @@ Once assigned, the identity MUST never change; `logical Ids` are always opaque, 
 
 For further background, refer to principles of [resource identity as described in the FHIR standard](http://www.hl7.org/implement/standards/fhir/STU3/resource.html#id)  
 
+
+### Referenced Resources ###
+Resources will commonly be referred to as part of other resources (e.g. a `GuidanceResponse` may refer to a `Questionnaire`). This guide is agnostic about whether the referenced resource is contained, or only available through a `GET`.
+
+
 ### Content types ###
 
 - The CDSS and EMS Servers MUST support both formal [MIME-types](https://www.hl7.org/fhir/STU3/http.html#mime-type) for FHIR resources:

--- a/pages/explore/api_get_questionnaire.md
+++ b/pages/explore/api_get_questionnaire.md
@@ -111,8 +111,11 @@ The CDSS can request this resource from the EMS using the HTTP GET verb and `_id
 View [CDS implementation guidance for a QuestionnaireResponse](api_questionnaire_response.html).
 
 ## Observation ##
-On receipt of the `QuestionnaireResponse`, the CDSS will use its contents to create and populate an [Observation](http://hl7.org/fhir/stu3/observation.html) resource, a reference to which is added to the `GuidanceResponse.outputParameters` returned to the EMS.  
-The CDSS will create the `Observation` using the same FHIR RESTful create interaction as outlined above for the [creation of a Questionnaire](#create-questionnaire).
+
+On receipt of the `QuestionnaireResponse`, the CDSS will use its contents to create an assertion, typically as an [Observation](http://hl7.org/fhir/stu3/observation.html) resource, a reference to which is added to the `GuidanceResponse.outputParameters` returned to the EMS. Note that `QuestionnaireResponse` and assertions will typically be one to one, but do not have to be. A CDSS can create multiple assertions from a single `QuestionnaireResponse`, and may also use multiple `QuestionnaireResponses` to be sure of a single assertion.
+
+The CDSS will create the `Observation` (or other resource appropriate for the assertion) using the same FHIR RESTful create interaction as outlined above for the [creation of a Questionnaire](#create-questionnaire).
+
 
 <!-- ## Example Scenario ##
 Placeholder -->

--- a/pages/explore/api_get_service_definition.md
+++ b/pages/explore/api_get_service_definition.md
@@ -18,7 +18,7 @@ This action is performed by the Encounter Management System (EMS) in order to ge
 
 When the CDSS publishes a `ServiceDefinition`, the `ServiceDefinition` will have elements which describe how the `ServiceDefinition` can be used. The description of where in the clinical process a `ServiceDefinition` sits is described in the `ServiceDefinition.trigger`. This element will hold all the data conditions which need to be satisfied for the `ServiceDefinition` to be chosen.
 
-The `ServiceDefinition.trigger` will typically be defined through Observation resources which must be true in order for the `ServiceDefinition` to be suitable for evaluation. For a given CDSS, these will typically be aligned to the `ServiceDefinition.dataRequirements` of a prior `ServiceDefinition`.
+The `ServiceDefinition.trigger` will typically be defined through Observation resources which MUST be true in order for the `ServiceDefinition` to be suitable for evaluation. For a given CDSS, these will typically be aligned to the `ServiceDefinition.dataRequirements` of a prior `ServiceDefinition`.
 
 Each CDSS SHOULD provide a `ServiceDefinition` where the trigger is NULL (i.e. no information is required).
 

--- a/pages/explore/api_get_service_definition.md
+++ b/pages/explore/api_get_service_definition.md
@@ -14,7 +14,15 @@ summary: Select a ServiceDefinition interaction
 -->
 
 ## Select ServiceDefinition Interaction ##
-This action is performed by the Encounter Management System (EMS) in order to get a [ServiceDefinition](http://hl7.org/fhir/stu3/servicedefinition.html) from one pre-selected Clinical Decision Support System (CDSS).  
+This action is performed by the Encounter Management System (EMS) in order to get a `ServiceDefinition` from a Clinical Decision Support System (CDSS).
+
+When the CDSS publishes a `ServiceDefinition`, the `ServiceDefinition` will have elements which describe how the `ServiceDefinition` can be used. The description of where in the clinical process a `ServiceDefinition` sits is described in the `ServiceDefinition.trigger`. This element will hold all the data conditions which need to be satisfied for the `ServiceDefinition` to be chosen.
+
+The `ServiceDefinition.trigger` will typically be defined through Observation resources which must be true in order for the `ServiceDefinition` to be suitable for evaluation. For a given CDSS, these will typically be aligned to the `ServiceDefinition.dataRequirements` of a prior `ServiceDefinition`.
+
+Each CDSS SHOULD provide a `ServiceDefinition` where the trigger is NULL (i.e. no information is required).
+
+During a given patient journey, there may be points where there is more than one `ServiceDefinition` available. Any one CDSS should avoid this situation, but if a provider has more than one CDSS available, there may be situations where more than one CDSS can provide an appropriate `ServiceDefinition`. In this case, it will be up to local providers on how to choose between the available ServiceDefinitions. 
 
 ## Request Headers ##
 The following HTTP request headers are supported for this interaction: 

--- a/pages/explore/api_guidance_response.md
+++ b/pages/explore/api_guidance_response.md
@@ -30,7 +30,7 @@ The table below details implementation guidance for the [GuidanceResponse](http:
     <td><code class="highlighter-rouge">0..1</code></td>
     <td>id</td>
     <td>The id of the request associated with this response, if any.</td>
-<td>This MUST be populated by the CDSS and must replicate the requestId received by the CDSS as a parameter in the <code class="highlighter-rouge">ServiceDefinition.$evaluate</code> operation.</td>
+<td>This MUST be populated by the CDSS and MUST replicate the requestId received by the CDSS as a parameter in the <code class="highlighter-rouge">ServiceDefinition.$evaluate</code> operation.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">identifier</code></td>
@@ -108,7 +108,7 @@ The table below details implementation guidance for the [GuidanceResponse](http:
     <td>Reference<br>(Parameters)</td>
     <td>The output parameters of the evaluation, if any.</td>
 <td>This element carries the state of the patient triage and MUST be populated with the current state. The state is managed through <code class="highlighter-rouge">QuestionnaireResponse</code> elements (as provided by the user), assertions based on these responses which can be interpreted by other systems, and any other resources provided by the EMS, typically from external systems (e.g. known patient conditions).  
-Where an <code class="highlighter-rouge">outputParameter</code> can be interpreted by a system, it should be published as an Observation. If the information can only be interpreted by a human, it can be published as a <code class="highlighter-rouge">QuestionnaireResponse</code> only.
+Where an <code class="highlighter-rouge">outputParameter</code> can be interpreted by a system, it SHOULD be published as an Observation. If the information can only be interpreted by a human, it can be published as a <code class="highlighter-rouge">QuestionnaireResponse</code> only.
 </td>
  </tr>
 <tr>
@@ -141,10 +141,10 @@ This element contains the output parameters of the evaluation and is critical be
 Further guidance about the population of this element can be viewed on the [Result interaction](api_return_guidance_response.html) page.  
 
 ### DataRequirement element of the GuidanceResponse ###  
-The scenarios in which this element may be used are outlined below:-  
+The scenarios in which this element MAY be used are outlined below:-  
  
 #### Evaluation against the currently selected ServiceDefinition ####  
-If information is lacking for the evaluation to be completed or additional information could result in a more accurate response, this element will carry a description of the data required in order to proceed with the evaluation. A subsequent request to the service should include this data.  
+If information is lacking for the evaluation to be completed or additional information could result in a more accurate response, this element will carry a description of the data required in order to proceed with the evaluation. A subsequent request to the service SHOULD include this data.  
 
 #### Re-direction to a new ServiceDefinition ####
 In this scenario, the element will carry a description of the data required by the EMS to select the new `ServiceDefinition` to which it is being re-directed by the CDSS.  

--- a/pages/explore/api_guidance_response.md
+++ b/pages/explore/api_guidance_response.md
@@ -65,7 +65,10 @@ The table below details implementation guidance for the [GuidanceResponse](http:
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>Reference<br>(Encounter|<br>EpisodeOfCare)</td>
     <td>Encounter or Episode during which the response was returned.</td>
-<td>This SHOULD be populated by the CDSS; if received by the CDSS, it is taken from the encounter parameter in the <code class="highlighter-rouge">ServiceDefinition.$evaluate</code> operation.</td>
+<td>This SHOULD be populated by the CDSS; if received by the CDSS, it is taken from the encounter parameter in the <code class="highlighter-rouge">ServiceDefinition.$evaluate</code> operation.
+<br>
+This MUST be populated with the Encounter for this journey, from the <code class="highlighter-rouge">ServiceDefinition.$evaluate.encounter</code>
+</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">occurrenceDateTime</code></td>

--- a/pages/explore/api_guidance_response.md
+++ b/pages/explore/api_guidance_response.md
@@ -107,8 +107,9 @@ The table below details implementation guidance for the [GuidanceResponse](http:
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>Reference<br>(Parameters)</td>
     <td>The output parameters of the evaluation, if any.</td>
-<td>This element carries the state of the patient triage and MUST be populated with the current state. The state is managed through <code class="highlighter-rouge">QuestionnaireResponse</code> elements (as provided by the user), assertions based on these responses which can be interpreted by other systems, and any other resources provided by the EMS, typically from external systems (e.g. known patient conditions).  
-Where an <code class="highlighter-rouge">outputParameter</code> can be interpreted by a system, it SHOULD be published as an Observation. If the information can only be interpreted by a human, it can be published as a <code class="highlighter-rouge">QuestionnaireResponse</code> only.
+<td>This element carries the state of the patient triage and MUST be populated with the current state. The state is managed through <code class="highlighter-rouge">QuestionnaireResponse</code> elements (as provided by the user); assertions (typically populated as <code class="highlighter-rouge">Observation</code> resources) based on these responses which can be interpreted by other systems; and any other resources provided by the EMS, typically from external systems (e.g. known patient conditions).
+<br>
+Where an <code class="highlighter-rouge">outputParameter</code> can be interpreted by a system, it SHOULD be published as an assertion, typically an <code class="highlighter-rouge">Observation</code>. If the information can only be interpreted by a human, it can be published as a <code class="highlighter-rouge">QuestionnaireResponse</code> only.
 </td>
  </tr>
 <tr>

--- a/pages/explore/api_observation.md
+++ b/pages/explore/api_observation.md
@@ -50,7 +50,7 @@ Detailed implementation guidance for an `Observation` resource in the CDS contex
       <td><code class="highlighter-rouge">1..1</code></td>
     <td>code</td>
     <td>registered | preliminary | final | amended + <a href="https://www.hl7.org/fhir/stu3/valueset-observation-status.html">ObservationStatus (Required)</a>.</td>
-<td>This will normally be 'final', but may be amended (where a user has amended their answers to a question).</td>
+<td>This will normally be 'final', but may be 'amended' (where a user has amended their answers to a question).</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">category</code></td>
@@ -63,7 +63,7 @@ Detailed implementation guidance for an `Observation` resource in the CDS contex
   <td><code class="highlighter-rouge">code</code></td>
       <td><code class="highlighter-rouge">1..1</code></td>
     <td>CodeableConcept</td>
-    <td>Type of observation (code/type)</td>
+    <td>Type of observation (code/type) <a href="https://www.hl7.org/fhir/stu3/valueset-observation-codes.html">LOINC Codes (Example)</a>.</td>
 <td>Snomed CT code for the <code class="highlighter-rouge">Observation</code>.</td>
  </tr>
 <tr>

--- a/pages/explore/api_observation.md
+++ b/pages/explore/api_observation.md
@@ -240,7 +240,7 @@ Detailed implementation guidance for an `Observation` resource in the CDS contex
       <td><code class="highlighter-rouge">1..1</code></td>
  <td>CodeableConcept</td>
     <td>Type of component observation (code/type) <a href="https://www.hl7.org/fhir/stu3/valueset-observation-codes.html">LOINC Codes (Example)</a></td>
-    <td></td>
+    <td>Snomed CT code for the <code class="highlighter-rouge">Observation</code>.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">component.value[x]</code></td>

--- a/pages/explore/api_observation.md
+++ b/pages/explore/api_observation.md
@@ -1,0 +1,282 @@
+﻿---
+title: UEC Digital Integration Programme | Observation implementation guidance
+keywords: observation, rest,
+tags: [rest,fhir,api]
+sidebar: ctp_rest_sidebar
+permalink: api_observation.html
+summary: Observation resource implementation guidance
+---
+
+{% include custom/search.warnbanner.html %}
+<!--
+{% include custom/fhir.referencemin.html resource="" userlink="" page="" fhirname="Questionnaire" fhirlink="[Questionnaire](http://hl7.org/fhir/stu3/questionnaire.html)" content="User Stories" userlink="" %}
+-->
+## Observation: Implementation Guidance ##
+
+### Usage ###
+The [Observation](http://hl7.org/fhir/stu3/observation.html) resource is used to carry a clinical assertion in a CDS context and is created and populated by a CDSS, which will work from clinical assertions to reach decisions.  
+Due to the nature of triage in unscheduled care, these assertions are often time-bounded and limited, so are appropriate to capture as `Observations`. The assertions are normally based on input from the patient, captured as `QuestionnaireResponses`.  
+A single `QuestionnaireResponse` can drive a single assertion, or multiple assertions.  
+Similarly, an assertion may need multiple `QuestionnaireResponses` to be validated.
+
+Detailed implementation guidance for an `Observation` resource in the CDS context is given below:  
+
+
+<table style="min-width:100%;width:100%">
+
+<tr>
+    <th style="width:10%;">Name</th>
+    <th style="width:5%;">Cardinality</th>
+    <th style="width:10%;">Type</th>
+      <th style="width:38%;">FHIR Documentation</th>
+   <th style="width:37%;">CDS Implementation Guidance</th>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">identifier</code></td>
+    <td><code class="highlighter-rouge">0..*</code></td>
+    <td>Identifier</td>
+    <td>Business Identifier for observation</td>
+<td>A unique identifier for the <code class="highlighter-rouge">Observation</code>.</td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">basedOn</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+    <td>Reference<br>(Careplan |<br>DeviceRequest |<br>Immunization<br>Recommendation |<br>MedicationRequest |<br>NutritionOrder |<br>ProcedureRequest |<br>ReferralRequest)</td>
+    <td>Fulfills plan, proposal or order</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">status</code></td>
+      <td><code class="highlighter-rouge">1..1</code></td>
+    <td>code</td>
+    <td>registered | preliminary | final | amended + <a href="https://www.hl7.org/fhir/stu3/valueset-observation-status.html">ObservationStatus (Required)</a>.</td>
+<td>This will normally be 'final', but may be amended (where a user has amended their answers to a question).</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">category</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+   <td>CodeableConcept</td>
+    <td>Classification of type of observation <a href="https://www.hl7.org/fhir/stu3/valueset-observation-category.html">Observation Category Codes (Preferred)</a>.</td>
+<td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">code</code></td>
+      <td><code class="highlighter-rouge">1..1</code></td>
+    <td>CodeableConcept</td>
+    <td>Type of observation (code/type)</td>
+<td>Snomed CT code for the <code class="highlighter-rouge">Observation</code>.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">subject</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>Reference<br>(Patient |<br>Group |<br>Device |<br>Location)</td>
+    <td>Who and/or what this is about</td>
+<td>This SHOULD NOT be populated.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">context</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+    <td>Reference<br>(Encounter |<br>EpisodeOfCare)</td>
+    <td>Healthcare event during which this observation is made</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">effective[x]</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+     <td>dateTime |<br>Period</td>
+    <td>Clinically relevant time/time-period for observation</td>
+<td>This SHOULD be populated.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">issued</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+    <td>instant</td>
+    <td>Date/Time this was made available</td>
+<td>This SHOULD be populated.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">performer</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+    <td>Reference<br>(Practitioner |<br>Organization |<br>Patient |<br>RelatedPerson)</td>
+    <td>Who is responsible for the observation</td>
+<td>This SHOULD be populated with a reference to the organisation of the service provider which would be taken from the <code class="highlighter-rouge">ServiceDefinition.$evaluate.inputParameters</code> element.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">value[x]</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+      <td>Quantity | CodeableConcept | string | boolean | Range | Ratio | SampledData | Attachment | time | dateTime | Period</td>
+<td>Actual result</td>
+<td>This may be of any type, but will often be of type <code class="highlighter-rouge">valueBoolean</code> to indicate the presence or absence of the Observation type recorded in the <code class="highlighter-rouge">Observation.code</code> element.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">dataAbsentReason</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>Why the result is missing <a href="https://www.hl7.org/fhir/stu3/valueset-observation-valueabsentreason.html">Observation Value Absent Reason (Extensible)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">interpretation</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>High, low, normal, etc. <a href="https://www.hl7.org/fhir/stu3/valueset-observation-interpretation.html">Observation Interpretation Codes (Extensible)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">comment</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+    <td>string</td>
+    <td>Comments about result</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">bodySite</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>Observed body part <a href="https://www.hl7.org/fhir/stu3/valueset-body-site.html">SNOMED CT Body Structures (Example)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">method</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>How it was done <a href="https://www.hl7.org/fhir/stu3/valueset-observation-methods.html">Observation Methods (Example)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">specimen</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+    <td>Reference(Specimen)</td>
+  <td>Specimen used for this observation</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">device</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+    <td>Reference<br>(Device |<br>DeviceMetric)</td>
+    <td>(Measurement) Device</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+    <td>BackboneElement</td>
+    <td>Provides guide for interpretation<br>
++ Must have at least a low or a high or text</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.low</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>SimpleQuantity</td>
+    <td>Low Range, if relevant</td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.high</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>SimpleQuantity</td>
+    <td>High Range, if relevant</td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.type</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>CodeableConcept</td>
+    <td>Reference range qualifier <a href="https://www.hl7.org/fhir/stu3/valueset-referencerange-meaning.html">Observation Reference Range Meaning Codes (Extensible)</a></td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.appliesTo</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+ <td>CodeableConcept</td>
+    <td>Reference range population <a href="https://www.hl7.org/fhir/stu3/valueset-referencerange-appliesto.html">Observation Reference Range Applies To Codes (Example)</a></td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.age</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>Range</td>
+    <td>Applicable age range, if relevant</td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">referenceRange.text</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>string</td>
+    <td>Text based reference range in an observation</td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">related</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+    <td>BackboneElement</td>
+    <td>Resource related to this observation</td>
+<td>This SHOULD be populated with the <code class="highlighter-rouge">QuestionnaireResponse</code> resources which affected the population of this <code class="highlighter-rouge">Observation</code>.</td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">related.type</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+ <td>code</td>
+    <td>has-member | derived-from | sequel-to | replaces | qualified-by | interfered-by <a href="https://www.hl7.org/fhir/stu3/valueset-observation-relationshiptypes.html">ObservationRelationshipType (Required)</a></td>
+    <td>This should be populated with the value 'derived-from'.</td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">related.target</code></td>
+      <td><code class="highlighter-rouge">1..1</code></td>
+ <td>Reference<br>(Observation |<br>Questionnaire<br>Response |<br>Sequence)</td>
+    <td>Resource that is related to this one</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">component</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+    <td>BackboneElement</td>
+    <td>Component results</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">component.code</code></td>
+      <td><code class="highlighter-rouge">1..1</code></td>
+ <td>CodeableConcept</td>
+    <td>Type of component observation (code/type) <a href="https://www.hl7.org/fhir/stu3/valueset-observation-codes.html">LOINC Codes (Example)</a></td>
+    <td></td>
+</tr>
+<tr>
+  <td><code class="highlighter-rouge">component.value[x]</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+      <td>Quantity | CodeableConcept | string | Range | Ratio | SampledData | Attachment | time | dateTime | Period</td>
+<td>Actual component result</td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">component.dataAbsentReason</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>Why the component result is missing <a href="https://www.hl7.org/fhir/stu3/valueset-observation-valueabsentreason.html">Observation Value Absent Reason (Extensible)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">component.interpretation</code></td>
+      <td><code class="highlighter-rouge">0..1</code></td>
+   <td>CodeableConcept</td>
+    <td>High, low, normal, etc. <a href="https://www.hl7.org/fhir/stu3/valueset-observation-interpretation.html">Observation Interpretation Codes (Extensible)</a></td>
+<td></td>
+ </tr>
+<tr>
+  <td><code class="highlighter-rouge">component.referenceRange</code></td>
+      <td><code class="highlighter-rouge">0..*</code></td>
+   <td>see referenceRange</td>
+    <td>Provides guide for interpretation of component result</td>
+<td></td>
+ </tr>
+</table>
+
+<!-- ## Example Scenario ##
+Placeholder -->
+
+
+
+
+
+

--- a/pages/explore/api_post_service_definition.md
+++ b/pages/explore/api_post_service_definition.md
@@ -57,7 +57,7 @@ The CDSS will return a `GuidanceResponse` resource as the OUT parameter of the o
     <td><code class="highlighter-rouge">0..1</code></td>
     <td>id</td>
     <td>An optional client-provided identifier to track the request.</td>
-<td>MUST be provided by the EMS. This id must be persisted through a patient journey</td>
+<td>MUST be provided by the EMS. This id MUST be persisted through a patient journey</td>
 </tr>
 <tr>
    <td><code class="highlighter-rouge">evaluateAtDateTime</code></td>
@@ -125,7 +125,7 @@ If no value is provided, the date and time of the request is assumed.</td>
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>CodeableConcept</td>
     <td>The type of user initiating the request, e.g. patient, healthcare provider, or specific type of healthcare provider (physician, nurse, etc.).</td>
-<td>The <a href="#usertype-element">userType parameter of note</a> MUST be provided by the EMS. If the <code class="highlighter-rouge">userType</code> is patient, then the CDSS should use first person pronouns.</td>
+<td>The <a href="#usertype-element">userType parameter of note</a> MUST be provided by the EMS. If the <code class="highlighter-rouge">userType</code> is patient, then the CDSS SHOULD use first person pronouns.</td>
  </tr>
 <tr>
     <td><code class="highlighter-rouge">userLanguage</code></td>

--- a/pages/explore/api_post_service_definition.md
+++ b/pages/explore/api_post_service_definition.md
@@ -83,12 +83,10 @@ If no value is provided, the date and time of the request is assumed.</td>
     <td>The input data for the request. These data are defined by the data requirements of the module and typically provide patient-dependent information.</td>
    <td>The <a href="api_post_service_definition.html#inputdata-element">inputData element</a> MUST be populated with FHIR resources detailing the current state of the triage journey as follows:  
 <ul>  
-<li><code class="highlighter-rouge">GuidanceResponse</code> outputParameters supplied by any CDSS. Any relevant information taken from other (external) systems SHOULD be included.</li> 
-<li>Any <code class="highlighter-rouge">QuestionnaireResponse(s)</code> available from the user. Note that this MAY include <code class="highlighter-rouge">QuestionnaireResponse(s)</code> which have been amended. These MUST be addressed by the CDSS and the assertions updated.</li>
-</ul>
-<ul>
-<li>The CDSS MUST filter the supplied inputData and disregard any information not relevant for the <code class="highlighter-rouge">ServiceDefinition</code>.</li> 
-<li>The EMS MUST NOT send duplicate items.</li>
+<li>All assertions current for this triage (typically Observation resources). This includes all <code class="highlighter-rouge">GuidanceResponse outputParameters</code> supplied by any CDSS. Any relevant information taken from other (external) systems SHOULD be included.</li> 
+<li>Any <code class="highlighter-rouge">QuestionnaireResponse(s)</code> available from the user. Note that this MAY include <code class="highlighter-rouge">QuestionnaireResponse(s)</code> which have been amended. These MUST be addressed by the CDSS and the assertions updated.
+<br>The CDSS MUST filter the supplied inputData and disregard any information not relevant for the <code class="highlighter-rouge">ServiceDefinition</code>.
+<br>The EMS MUST NOT send duplicate items.</li>
 </ul>
 </td>
 </tr> 

--- a/pages/explore/api_provenance.md
+++ b/pages/explore/api_provenance.md
@@ -34,7 +34,7 @@ The table below details implementation guidance for this resource in the CDS con
     <td><code class="highlighter-rouge">1..*</code></td>
     <td>Reference(Any)</td>
     <td>Target Reference(s) (usually version specific)</td>
-<td>This MUST be populated by the CDSS and must carry the <a href="http://hl7.org/fhir/STU3/resource.html#id">logical ID</a> of the <code class="highlighter-rouge">ReferralRequest</code> that was generated or updated by the activity described in this resource.</td>
+<td>This MUST be populated by the CDSS and MUST carry the <a href="http://hl7.org/fhir/STU3/resource.html#id">logical ID</a> of the <code class="highlighter-rouge">ReferralRequest</code> that was generated or updated by the activity described in this resource.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">period</code></td>
@@ -118,7 +118,7 @@ The table below details implementation guidance for this resource in the CDS con
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>BackboneElement</td>
     <td>An entity used in this activity</td>
-<td>Multiple userIds may be associated with the same Practitioner or other individual across various appearances, each with distinct privileges.</td>
+<td>Multiple userIds MAY be associated with the same Practitioner or other individual across various appearances, each with distinct privileges.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">entity.role</code></td>
@@ -132,7 +132,7 @@ The table below details implementation guidance for this resource in the CDS con
      <td><code class="highlighter-rouge">1..1</code></td>
     <td><code class="highlighter-rouge">whatUri</code> uri <br><code class="highlighter-rouge">whatReference</code> <br> Reference(Any)<br><code class="highlighter-rouge">whatIdentifier</code> <br> Identifier</td>
     <td>Identity of entity</td>
-<td>Identity of the entity used. May be a logical or physical uri and maybe absolute or relative.</td>
+<td>Identity of the entity used. MAY be a logical or physical uri and maybe absolute or relative.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">entity.agent</code></td>
@@ -146,6 +146,6 @@ The table below details implementation guidance for this resource in the CDS con
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>Signature</td>
     <td>Signature on target</td>
-<td>This element carries a digital signature on the target Reference(s). The signer should match a Provenance.agent.</td>
+<td>This element carries a digital signature on the target Reference(s). The signer SHOULD match a Provenance.agent.</td>
  </tr>
 </table>

--- a/pages/explore/api_questionnaire.md
+++ b/pages/explore/api_questionnaire.md
@@ -216,7 +216,7 @@ Detailed implementation guidance for a `Questionnaire` resource in the CDS conte
       <td><code class="highlighter-rouge">1..1</code></td>
     <td>code</td>
     <td>group | display | boolean | decimal | integer | date | dateTime + <a href="https://www.hl7.org/fhir/stu3/valueset-item-type.html">QuestionnaireItemType (Required)</a></td>
-<td>The type of questionnaire item this is. If this is set to 'group', the EMS User interface must present all sub-items together to the user, with the group item description as the header.</td>
+<td>The type of questionnaire item this is. If this is set to 'group', the EMS User interface MUST present all sub-items together to the user, with the group item description as the header.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">item.enableWhen</code></td>
@@ -243,7 +243,7 @@ Detailed implementation guidance for a `Questionnaire` resource in the CDS conte
   <td><code class="highlighter-rouge">item.enableWhen.answer[x]</code></td>
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>boolean | decimal |<br>integer | date |<br>dateTime | time |<br>string | uri |<br>Attachment |<br> Coding |<br>Quantity | Reference(Any)</td>
-    <td>Value question must have <a href="https://www.hl7.org/fhir/stu3/valueset-questionnaire-answers.html">Questionnaire Answer Codes (Example)</a></td>
+    <td>Value question MUST have <a href="https://www.hl7.org/fhir/stu3/valueset-questionnaire-answers.html">Questionnaire Answer Codes (Example)</a></td>
 <td>This element will be populated by the CDSS and the EMS will display the value that it receives.</td>
  </tr>
 <tr>
@@ -251,14 +251,14 @@ Detailed implementation guidance for a `Questionnaire` resource in the CDS conte
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>boolean</td>
   <td>Whether the item must be included in data results</td>
-<td>If this element is true, then the EMS User interface must ensure the user provides an answer. If false, the User interface must allow the user to skip the question.</td>
+<td>If this element is true, then the EMS User interface MUST ensure the user provides an answer. If false, the User interface MUST allow the user to skip the question.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">item.repeats</code></td>
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>boolean</td>
   <td>Whether the item may repeat</td>
-<td>If this option is false, then the EMS User interface must only allow a single response to be selected. If the option is true, then multiple responses can be selected.</td>
+<td>If this option is false, then the EMS User interface MUST only allow a single response to be selected. If the option is true, then multiple responses can be selected.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">item.readOnly</code></td>
@@ -279,20 +279,20 @@ Detailed implementation guidance for a `Questionnaire` resource in the CDS conte
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>Reference(ValueSet)</td>
   <td>Valueset containing permitted answers</td>
-<td>This element MAY be populated by the CDSS, and if so, the EMS must provide the set of possible answers to the user who must choose one of the provided options. The use of this element is not recommended.</td>
+<td>This element MAY be populated by the CDSS, and if so, the EMS MUST provide the set of possible answers to the user who MUST choose one of the provided options. The use of this element is not recommended.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">item.option</code></td>
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>BackboneElement</td>
   <td>Permitted answer</td>
-<td>Where the question has multiple options, only one of which should be selected, these options can be enumerated in this element.</td>
+<td>Where the question has multiple options, only one of which SHOULD be selected, these options can be enumerated in this element.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">item.option.value[x]</code></td>
       <td><code class="highlighter-rouge">1..1</code></td>
      <td>integer | date |<br>time | string |<br> Coding</td>
-    <td>Value question must have <a href="https://www.hl7.org/fhir/stu3/valueset-questionnaire-answers.html">Questionnaire Answer Codes (Example)</a></td>
+    <td>Value question MUST have <a href="https://www.hl7.org/fhir/stu3/valueset-questionnaire-answers.html">Questionnaire Answer Codes (Example)</a></td>
 <td>This element will be populated by the CDSS and the EMS will display the value that it receives.</td>
  </tr>
 <tr>

--- a/pages/explore/api_questionnaire_response.md
+++ b/pages/explore/api_questionnaire_response.md
@@ -70,7 +70,7 @@ Detailed implementation guidance for a `QuestionnaireResponse` resource in the C
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>Reference(Any)</td>
     <td>The subject of the questions</td>
-<td>This SHOULD be populated with a reference to the <code class="highlighter-rouge">Patient</code> resource.</td>
+<td>This SHOULD NOT be populated.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">context</code></td>

--- a/pages/explore/api_questionnaire_response.md
+++ b/pages/explore/api_questionnaire_response.md
@@ -77,7 +77,10 @@ Detailed implementation guidance for a `QuestionnaireResponse` resource in the C
       <td><code class="highlighter-rouge">0..1</code></td>
   <td>Reference |<br>(Encounter |<br>EpisodeOfCare)</td>
     <td>Encounter or Episode during which questionnaire was completed</td>
-<td>This SHOULD be populated with the same details as those carried in the <code class="highlighter-rouge">ServiceDefinition.$evaluate.encounter</code> element.</td>
+<td>This SHOULD be populated with the same details as those carried in the <code class="highlighter-rouge">ServiceDefinition.$evaluate.encounter</code> element.
+<br>
+This MUST be populated with the Encounter for this journey, which is the same as the <code class="highlighter-rouge">ServiceDefinition.$evaluate.encounter</code>
+</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">authored</code></td>

--- a/pages/explore/api_referral_request.md
+++ b/pages/explore/api_referral_request.md
@@ -107,7 +107,7 @@ If the CDSS is recommending triage to another service, the <code class="highligh
       <td><code class="highlighter-rouge">1..1</code></td>
     <td>Reference<br>(Patient|<br>Group)</td>
     <td>Patient referred to care or transfer</td>
-<td>This MUST be populated with the <a href="http://hl7.org/fhir/STU3/resource.html#id">logical id</a> of the <code class="highlighter-rouge">Patient</code> resource.</td>
+<td>This SHOULD NOT be populated</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">context</code></td>

--- a/pages/explore/api_referral_request.md
+++ b/pages/explore/api_referral_request.md
@@ -17,8 +17,8 @@ summary: ReferralRequest resource implementation guidance
 ### Usage ###
 Within the Clinical Decision Support API implementation, the [ReferralRequest](http://hl7.org/fhir/stu3/referralrequest.html) resource will be used to carry the triage outcome of recommendation to another service for a patient.  
 A reference to the relevant `ReferralRequest` will be carried in the `action.resource` element of the `RequestGroup` resource in the form of the [logical id](http://hl7.org/fhir/STU3/resource.html#id) of the `ReferralRequest`.  
-The `ReferralRequest` may reference a `ProcedureRequest`, where there is a known [requested procedure](#procedure-request) which the referring service is intended to perform.  
-`RequestGroup.action.resource` may also carry a reference to one or more `CarePlans` to carry accompanying [care advice](api_care_plan.html) (not self-care) for the patient.  
+The `ReferralRequest` MAY reference a `ProcedureRequest`, where there is a known [requested procedure](#procedure-request) which the referring service is intended to perform.  
+`RequestGroup.action.resource` MAY also carry a reference to one or more `CarePlans` to carry accompanying [care advice](api_care_plan.html) (not self-care) for the patient.  
 Detailed implementation guidance for a `ReferralRequest` resource in the CDS context is given below:  
 
 
@@ -50,7 +50,7 @@ Detailed implementation guidance for a `ReferralRequest` resource in the CDS con
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>Reference<br>(ReferralRequest |<br>Careplan |<br>ProcedureRequest)</td>
     <td>Request fulfilled by this request</td>
-<td>This SHOULD be populated with a <code class="highlighter-rouge">ProcedureRequest</code>, where the <code class="highlighter-rouge">ProcedureRequest</code> contains the information on the next activity to be performed in order to identify the patient's health need. This <code class="highlighter-rouge">ProcedureRequest</code> will be a procedure that the current service is unable to perform, but that the recipient must be able to be perform.</td>
+<td>This SHOULD be populated with a <code class="highlighter-rouge">ProcedureRequest</code>, where the <code class="highlighter-rouge">ProcedureRequest</code> contains the information on the next activity to be performed in order to identify the patient's health need. This <code class="highlighter-rouge">ProcedureRequest</code> will be a procedure that the current service is unable to perform, but that the recipient MUST be able to be perform.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">replaces</code></td>
@@ -178,7 +178,7 @@ This is represented as a start time (now) and end time (now+3 days, or now+four 
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>Reference<br>(Condition |<br>Observation)</td>
     <td>Why is service needed?</td>
-<td>This SHOULD be populated by the CDSS. The chief concern should be carried in this element.</td>
+<td>This SHOULD be populated by the CDSS. The chief concern SHOULD be carried in this element.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">description</code></td>
@@ -192,7 +192,7 @@ This is represented as a start time (now) and end time (now+3 days, or now+four 
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>Reference<br>(Any)</td>
     <td>Additonal information to support referral or transfer of care request</td>
-<td>This SHOULD be populated by the CDSS. Secondary concerns should be be carried in this element.</td>
+<td>This SHOULD be populated by the CDSS. Secondary concerns SHOULD be be carried in this element.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">note</code></td>
@@ -212,21 +212,21 @@ This is represented as a start time (now) and end time (now+3 days, or now+four 
 
 ## Procedure Request ##  
 The `ProcedureRequest` is referenced from `ReferralRequest.basedOn`.  
-This will be the diagnostic discriminator, or service requirement; diagnostic discriminator is a description of the next procedure which should be carried out in the referee service to validate or eliminate the chief concern.  
+This will be the diagnostic discriminator, or service requirement; diagnostic discriminator is a description of the next procedure which SHOULD be carried out in the referee service to validate or eliminate the chief concern.  
 
 ### ProcedureRequest elements of note ###  
 
 #### Status element of the ProcedureRequest ####  
-This shows the status of the `ProcedureRequest` and should carry the value 'active'.
+This shows the status of the `ProcedureRequest` and SHOULD carry the value 'active'.
 
 #### Intent element of the ProcedureRequest ####  
-The population of this element shows whether the request is a proposal, plan, an original order or a reflex order. It should carry the value 'proposal'.  
+The population of this element shows whether the request is a proposal, plan, an original order or a reflex order. It SHOULD carry the value 'proposal'.  
 
 #### Code element of the ProcedureRequest #### 
 This element carries a code denoting the type of procedure being requested.
 
 #### Subject element of the ProcedureRequest #### 
-This element should always reference a `Patient` resource.
+This element SHOULD always reference a `Patient` resource.
 
 
 

--- a/pages/explore/api_return_guidance_response.md
+++ b/pages/explore/api_return_guidance_response.md
@@ -219,18 +219,9 @@ The table below gives additional information relating to outcome scenarios when 
 </table>
 
 ### OutputParameters of the returned GuidanceResponse ###  
-The `GuidanceResponse.status` element carries questions and assertions (resulting from the EMS's responses to received questions) sent to the EMS by the CDSS.  
-Where the data carried in `outputParameters` can be interpreted by a system, it SHOULD be published as an [Observation](http://hl7.org/fhir/stu3/observation.html). This could be done by the CDSS when it receives responses to received questions from the EMS.  
+The `GuidanceResponse.outputParameters` element carries assertions (resulting from the EMS’s responses to received questions) sent to the EMS by the CDSS. It also carries the `QuestionnaireResponse` resources created by the EMS, from user input. Where the data carried in `outputParameters` can be interpreted by a system, it SHOULD be published as an assertion, typically by populating an  [Observation](http://hl7.org/fhir/stu3/observation.html) resource. This is done by the CDSS when it receives responses to received questions from the EMS.
 
-If the information can only be interpreted by a human, it SHOULD be published as a [QuestionnaireResponse](http://hl7.org/fhir/stu3/questionnaireresponse.html). This resource could be published by the EMS as a response to questions received from the CDSS.  
-The [logical ID](http://hl7.org/fhir/STU3/resource.html#id) of either or both of these resources can be returned to the EMS by the CDSS for persistence and these IDs are carried as a reference in this element throughout the triage journey.
+If the information can only be interpreted by a human, it SHOULD be maintained as a [QuestionnaireResponse](http://hl7.org/fhir/stu3/questionnaireresponse.html) only. The [logical ID](http://hl7.org/fhir/STU3/resource.html#id) of either or both of these resources can be returned to the EMS by the CDSS for persistence and these IDs are carried as a reference in this element throughout the triage journey.
 
 ## GuidanceResponse: Implementation Guidance ##
 View [CDS implementation guidance for a GuidanceResponse](api_guidance_response.html).
-
-
-
-
-
-
-

--- a/pages/explore/api_return_guidance_response.md
+++ b/pages/explore/api_return_guidance_response.md
@@ -163,13 +163,13 @@ The table below gives additional information relating to outcome scenarios when 
   <td>The CDSS has sufficient information to recommend a referral, but additional information will provide a better result.</td>
     <td>data-requested</td>
     <td><code class="highlighter-rouge">GuidanceResponse</code> references <code class="highlighter-rouge">RequestGroup</code> which in turn references <code class="highlighter-rouge">ReferralRequest</code> to carry the information pertinent to the recommended referral.</td>
-<td>The <code class="highlighter-rouge">ReferralRequest</code> will have a <code class="highlighter-rouge">status</code> of 'draft' updating to 'active' when the finalised score is available.  When the result is final, the <code class="highlighter-rouge">GuidanceResponse.status</code> should be 'success' as above.</td>
+<td>The <code class="highlighter-rouge">ReferralRequest</code> will have a <code class="highlighter-rouge">status</code> of 'draft' updating to 'active' when the finalised score is available.  When the result is final, the <code class="highlighter-rouge">GuidanceResponse.status</code> SHOULD be 'success' as above.</td>
 </tr>
 <tr>
   <td>The CDSS has sufficient information to make a recommendation regarding what service the patient should use next and there is also a recommendation relating to a care plan (not self-care).</td>
     <td>data-requested</td>
     <td><code class="highlighter-rouge">GuidanceResponse</code> references <code class="highlighter-rouge">RequestGroup</code> which references <code class="highlighter-rouge">ReferralRequest</code> which in turn references <code class="highlighter-rouge">CarePlan</code>.</td>
-<td>The <code class="highlighter-rouge">ReferralRequest</code> and the <code class="highlighter-rouge">CarePlan</code> will have a <code class="highlighter-rouge">status</code> of 'draft' updating to 'active' when the finalised score is available. When the result is final, the <code class="highlighter-rouge">GuidanceResponse.status</code> should be 'success' as above.</td>
+<td>The <code class="highlighter-rouge">ReferralRequest</code> and the <code class="highlighter-rouge">CarePlan</code> will have a <code class="highlighter-rouge">status</code> of 'draft' updating to 'active' when the finalised score is available. When the result is final, the <code class="highlighter-rouge">GuidanceResponse.status</code> SHOULD be 'success' as above.</td>
 </tr>
 </table>
 
@@ -220,8 +220,9 @@ The table below gives additional information relating to outcome scenarios when 
 
 ### OutputParameters of the returned GuidanceResponse ###  
 The `GuidanceResponse.status` element carries questions and assertions (resulting from the EMS's responses to received questions) sent to the EMS by the CDSS.  
-Where the data carried in `outputParameters` can be interpreted by a system, it should be published as an [Observation](http://hl7.org/fhir/stu3/observation.html). This could be done by the CDSS when it receives responses to received questions from the EMS.  
-If the information can only be interpreted by a human, it should be published as a [QuestionnaireResponse](http://hl7.org/fhir/stu3/questionnaireresponse.html). This resource could be published by the EMS as a response to questions received from the CDSS.  
+Where the data carried in `outputParameters` can be interpreted by a system, it SHOULD be published as an [Observation](http://hl7.org/fhir/stu3/observation.html). This could be done by the CDSS when it receives responses to received questions from the EMS.  
+
+If the information can only be interpreted by a human, it SHOULD be published as a [QuestionnaireResponse](http://hl7.org/fhir/stu3/questionnaireresponse.html). This resource could be published by the EMS as a response to questions received from the CDSS.  
 The [logical ID](http://hl7.org/fhir/STU3/resource.html#id) of either or both of these resources can be returned to the EMS by the CDSS for persistence and these IDs are carried as a reference in this element throughout the triage journey.
 
 ## GuidanceResponse: Implementation Guidance ##

--- a/pages/explore/api_service_definition.md
+++ b/pages/explore/api_service_definition.md
@@ -15,7 +15,7 @@ summary: ServiceDefinition implementation guidance
 
 ### Usage ###
 The [Service Definition](http://hl7.org/fhir/stu3/servicedefinition.html) resource is published by the CDSS, describing what decisions the CDSS is able to provide support for. The resource describes in what circumstances the CDSS is valid, and what information is needed to render the decision.
-A CDSS can publish one or many `ServiceDefinition` resources. The resources should form a logically complete set. All CDSS must publish at least one `ServiceDefinition`.
+A CDSS can publish one or many `ServiceDefinition` resources. The resources SHOULD form a logically complete set. All CDSS MUST publish at least one `ServiceDefinition`.
 
 
 A `ServiceDefinition` can encapsulate any amount of information – some CDSS may find it simpler to have a single `ServiceDefinition`, and routing of patients through the CDSS is managed entirely within that single `ServiceDefinition`. Other CDSS may publish a different `ServiceDefinition` for different areas – for example, a `ServiceDefinition` for each presenting complaint. It is also possible to be even more granular, with a CDSS having a different `ServiceDefintion` for different complaints, and also for different types of user (e.g. headache for adult females, and a separate `ServiceDefinition` for headache for male children).
@@ -23,7 +23,7 @@ A `ServiceDefinition` can encapsulate any amount of information – some CDSS ma
 In general, more granular `ServiceDefinitions` will make change management simpler, as these can be updated without changing other `ServiceDefinitions`. Conversely, fewer `ServiceDefinitions` can make the triage journey simpler to control.
 
   
-Details of how a `ServiceDefinition` should be implemented within the Clinical Decision Support context is outlined in the table below:
+Details of how a `ServiceDefinition` SHOULD be implemented within the Clinical Decision Support context is outlined in the table below:
 
 <table style="min-width:100%;width:100%">
 
@@ -46,7 +46,7 @@ Details of how a `ServiceDefinition` should be implemented within the Clinical D
     <td><code class="highlighter-rouge">0..*</code></td>
     <td>Identifier</td>
     <td>Additional identifier for the service definition</td>
-<td>This is a business identifier and could be used to identify a <code class="highlighter-rouge">ServiceDefinition</code> where it is not possible to use the logical URI. This is generally used by FHIR servers.</td>
+<td>This is a business identifier and COULD be used to identify a <code class="highlighter-rouge">ServiceDefinition</code> where it is not possible to use the logical URI. This is generally used by FHIR servers.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">version</code></td>
@@ -60,7 +60,7 @@ Details of how a `ServiceDefinition` should be implemented within the Clinical D
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>string</td>
     <td>Name for this service definition (computer friendly)</td>
-<td>The name is not expected to be globally unique. The name should be a simple alpha-numeric type name. This is generally used by FHIR servers.</td>
+<td>The name is not expected to be globally unique. The name SHOULD be a simple alpha-numeric type name. This is generally used by FHIR servers.</td>
 </tr>
 <tr>
   <td><code class="highlighter-rouge">title</code></td>
@@ -144,7 +144,7 @@ Details of how a `ServiceDefinition` should be implemented within the Clinical D
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>UsageContext</td>
     <td>Context the content is intended to support</td>
-<td>This element SHOULD be populated with the appropriate expected usage of the <code class="highlighter-rouge">ServiceDefinition</code>. This will include patient gender, patient age group, user role/type.  These terms may be used to assist with indexing and searching for appropriate <code class="highlighter-rouge">ServiceDefinition</code> instances and so can assist an EMS in identifying the most appropriate service.</td>
+<td>This element SHOULD be populated with the appropriate expected usage of the <code class="highlighter-rouge">ServiceDefinition</code>. This will include patient gender, patient age group, user role/type.  These terms MAY be used to assist with indexing and searching for appropriate <code class="highlighter-rouge">ServiceDefinition</code> instances and so can assist an EMS in identifying the most appropriate service.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">jurisdiction</code></td>
@@ -165,7 +165,7 @@ Details of how a `ServiceDefinition` should be implemented within the Clinical D
       <td><code class="highlighter-rouge">0..*</code></td>
     <td>Contributor</td>
     <td>A content contributor</td>
-<td>The information in this element could be used to assist consumers in quickly determining who contributed to the content of the knowledge module.</td>
+<td>The information in this element COULD be used to assist consumers in quickly determining who contributed to the content of the knowledge module.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">contact</code></td>
@@ -179,7 +179,7 @@ Details of how a `ServiceDefinition` should be implemented within the Clinical D
       <td><code class="highlighter-rouge">0..1</code></td>
     <td>markdown</td>
     <td>Use and/or publishing restrictions</td>
-<td>Consumers must be able to determine any legal restrictions on the use of the <code class="highlighter-rouge">ServiceDefinition</code> and/or its content.</td>
+<td>Consumers MUST be able to determine any legal restrictions on the use of the <code class="highlighter-rouge">ServiceDefinition</code> and/or its content.</td>
  </tr>
 <tr>
   <td><code class="highlighter-rouge">relatedArtifact</code></td>

--- a/pages/explore/api_service_definition.md
+++ b/pages/explore/api_service_definition.md
@@ -14,8 +14,14 @@ summary: ServiceDefinition implementation guidance
 ## ServiceDefinition: Implementation Guidance ##  
 
 ### Usage ###
-The [Service Definition](http://hl7.org/fhir/stu3/servicedefinition.html) resource carries information describing the functionality made available by a specific service.  
-It does not carry details relating to how this functionality is performed, only about what the service module does plus its required inputs and the outputs it produces.  
+The [Service Definition](http://hl7.org/fhir/stu3/servicedefinition.html) resource is published by the CDSS, describing what decisions the CDSS is able to provide support for. The resource describes in what circumstances the CDSS is valid, and what information is needed to render the decision.
+A CDSS can publish one or many `ServiceDefinition` resources. The resources should form a logically complete set. All CDSS must publish at least one `ServiceDefinition`.
+
+
+A `ServiceDefinition` can encapsulate any amount of information – some CDSS may find it simpler to have a single `ServiceDefinition`, and routing of patients through the CDSS is managed entirely within that single `ServiceDefinition`. Other CDSS may publish a different `ServiceDefinition` for different areas – for example, a `ServiceDefinition` for each presenting complaint. It is also possible to be even more granular, with a CDSS having a different `ServiceDefintion` for different complaints, and also for different types of user (e.g. headache for adult females, and a separate `ServiceDefinition` for headache for male children).
+
+In general, more granular `ServiceDefinitions` will make change management simpler, as these can be updated without changing other `ServiceDefinitions`. Conversely, fewer `ServiceDefinitions` can make the triage journey simpler to control.
+
   
 Details of how a `ServiceDefinition` should be implemented within the Clinical Decision Support context is outlined in the table below:
 

--- a/pages/solution/solution_interactions.md
+++ b/pages/solution/solution_interactions.md
@@ -19,7 +19,7 @@ The key interactions for the Clinical Decision Support API are represented in th
 
 The triage journey starts with the system user requesting decision support through the EMS.
 
-The core of the triage journey is invoking the `ServiceDefinition` via the `$evaluate` operation by the EMS. This will return a `GuidanceResponse` resource from the CDSS.
+The core of the triage journey is invoking the `ServiceDefinition` via the `$evaluate` operation by the EMS. This will return a `GuidanceResponse` resource from the CDSS. For more on choosing the `ServiceDefinition`, see the [ServiceDefinition: Implementation Guidance](api_service_definition.html#servicedefinition-implementation-guidance). 
 
 This interaction is expected to be repeated multiple times during the triage journey as the EMS presents responses to CDSS questions until a result is reached. 
 


### PR DESCRIPTION
CTP-1465 Need to explain link between observation and service definition/trigger - date requirement etc
CTP-1476 Expectation setting text needed on Implentation guide agnostic about the approach as long as the FHIR standard followed
CTP-1418 Solution interactions: Needs rework to provide more context e.g. what is a service definition etc 
CTP-1511 Consistency: use of CAPS style for must, should and could, may where appropriate 
CTP-1421 [no action needed]
CTP-1471 Review consistency of use of the terms assertion/observation. Define in Glossary
CTP-1509 Use of encounter

CTP-1525 ReferralRequest.subject
CTP-1473 "FHIR Response" as a menu label should be reviewed as the section is primarily about implementation guidance.
CTP-1526 Note for implementors
CTP-1524 QuestionnaireResponse.subject
CTP-1387 Links to supporting programmes/ docs

Please note I did a command line pull from upstream develop branch (rather than a Github interface PR) which brought some changes by Katie into my repo, which have then been re-committed. This is why this PR has Katies name in it. Hopefully all still lines up.